### PR TITLE
add registry switch and refactor image values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Changed
+
+- add registry switch to allow installations to automatically set the image registry based on location
+
 ## [0.8.0] - 2022-09-21
 
 ### Changed

--- a/helm/linkerd2-multicluster-app/templates/gateway.yaml
+++ b/helm/linkerd2-multicluster-app/templates/gateway.yaml
@@ -40,7 +40,7 @@ spec:
       {{- end }}
       containers:
         - name: pause
-          image: quay.io/giantswarm/pause:3.2
+          image: {{.Values.image.registry}}/giantswarm/pause:3.2
       serviceAccountName: {{.Values.gateway.name}}
       securityContext:
         runAsUser: {{.Values.controllerUID}}

--- a/helm/linkerd2-multicluster-app/values.schema.json
+++ b/helm/linkerd2-multicluster-app/values.schema.json
@@ -11,6 +11,14 @@
         "enablePodAntiAffinity": {
             "type": "boolean"
         },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string"
+                }
+            }
+        },
         "gateway": {
             "type": "object",
             "properties": {

--- a/helm/linkerd2-multicluster-app/values.schema.json
+++ b/helm/linkerd2-multicluster-app/values.schema.json
@@ -11,14 +11,6 @@
         "enablePodAntiAffinity": {
             "type": "boolean"
         },
-        "image": {
-            "type": "object",
-            "properties": {
-                "registry": {
-                    "type": "string"
-                }
-            }
-        },
         "gateway": {
             "type": "object",
             "properties": {
@@ -61,6 +53,14 @@
         },
         "identityTrustDomain": {
             "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "registry": {
+                    "type": "string"
+                }
+            }
         },
         "installNamespace": {
             "type": "boolean"

--- a/helm/linkerd2-multicluster-app/values.yaml
+++ b/helm/linkerd2-multicluster-app/values.yaml
@@ -1,3 +1,6 @@
+image:
+  registry: quay.io
+
 gateway:
   # -- If the gateway component should be installed
   enabled: true

--- a/helm/linkerd2-multicluster-app/values.yaml
+++ b/helm/linkerd2-multicluster-app/values.yaml
@@ -1,3 +1,5 @@
+# -- Registry switch
+# Do not overwrite this as it is automatically set based on the installation region
 image:
   registry: quay.io
 

--- a/tests/ats/test-app-manifests.yaml
+++ b/tests/ats/test-app-manifests.yaml
@@ -127,7 +127,7 @@ spec:
                 - helloworld
             topologyKey: kubernetes.io/hostname
       containers:
-      - image: quay.io/giantswarm/helloworld:latest
+      - image: {{.Values.image.registry}}/giantswarm/helloworld:latest
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
This PR:

- adds a registry switch to allow installations to automatically set the image registry based on location

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

