### PR TITLE
Remove proxyProtocol field from gateway policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project's packages adheres to [Semantic Versioning](http://semver.org/s
 
 ## [Unreleased]
 
+### Fixed
+
+- Remove proxyProtocol filed from gateway policy which prevented routing traffic other than HTTP
+
 ## [0.9.0] - 2022-11-07
 
 ### Changed

--- a/helm/linkerd-multicluster/templates/gateway-policy.yaml
+++ b/helm/linkerd-multicluster/templates/gateway-policy.yaml
@@ -15,7 +15,6 @@ spec:
     matchLabels:
       app: {{.Values.gateway.name}}
   port: linkerd-proxy
-  proxyProtocol: HTTP/1
 ---
 apiVersion: policy.linkerd.io/v1beta1
 kind: ServerAuthorization


### PR DESCRIPTION
This PR:

- remove proxyProtocol field in gateway policy to allow traffic other than http
- align with [upstream commit](https://github.com/linkerd/linkerd2/commit/d6074899a0eb4808d0c895fb33e09ece26e9c4d1)

<!--
Changelog must always be updated.
-->

### Checklist

- [x] Update changelog in CHANGELOG.md.

